### PR TITLE
Defer helper registration to to_prepare for Rails 8.1 compatibility

### DIFF
--- a/lib/strata/engine.rb
+++ b/lib/strata/engine.rb
@@ -10,11 +10,6 @@ module Strata
   class Engine < ::Rails::Engine
     isolate_namespace Strata
 
-    # Registered as a to_prepare hook rather than an initializer: the
-    # :action_controller load hook can fire while initializers are still
-    # running, which is before Zeitwerk takes over and can autoload
-    # Strata::ApplicationHelper. to_prepare runs after the autoloaders are
-    # set up, and re-runs on reload.
     config.to_prepare do
       ActiveSupport.on_load :action_controller do
         helper Strata::ApplicationHelper

--- a/lib/strata/engine.rb
+++ b/lib/strata/engine.rb
@@ -10,7 +10,12 @@ module Strata
   class Engine < ::Rails::Engine
     isolate_namespace Strata
 
-    initializer "strata.helpers" do
+    # Registered as a to_prepare hook rather than an initializer: the
+    # :action_controller load hook can fire while initializers are still
+    # running, which is before Zeitwerk takes over and can autoload
+    # Strata::ApplicationHelper. to_prepare runs after the autoloaders are
+    # set up, and re-runs on reload.
+    config.to_prepare do
       ActiveSupport.on_load :action_controller do
         helper Strata::ApplicationHelper
       end


### PR DESCRIPTION
## Problem

On Rails 8.1, any app mounting this engine fails to boot:

```
NameError: uninitialized constant Strata::ApplicationHelper
# lib/strata/engine.rb:15:in 'block (2 levels) in <class:Engine>'
# activesupport-8.1.3.1/lib/active_support/lazy_load_hooks.rb:97:in 'Module#class_eval'
# railties-8.1.3.1/lib/rails/initializable.rb:24:in 'Rails::Initializable::Initializer#run'
# railties-8.1.3.1/lib/rails/application.rb:442:in 'Rails::Application#initialize!'
```

## Cause

Rails 8.1 rewrote `Rails::Initializable::Collection` (`Array` subclass → `Enumerable` + explicit `@order`/`@resolve` maps), which changed when the `:action_controller` load hook fires relative to engine initializers.

`ActiveSupport.on_load :action_controller` runs its block immediately if `ActionController::Base` is already loaded. Under 8.1 that now happens while initializers are still running — before the Finisher sets up Zeitwerk — so the autoloader can't resolve `Strata::ApplicationHelper` and the reference raises.

## Fix

Register through `config.to_prepare` instead of an initializer. `to_prepare` runs after the autoloaders are in place and re-runs on reload, which is also the more correct home for a hook that references a reloadable constant.

`to_prepare` long predates Rails 7, so this stays within the gemspec's `rails >= 7.2.2.2` floor and is a no-op behaviour change on 8.0.

## Verification

Against [`navapbc/oscer`](https://github.com/navapbc/oscer) `reporting-app` on `rails 8.1.3.1`, strata pinned at `f3b47ca` (current `main`):

| | Result |
|---|---|
| Without this change | App cannot boot — `NameError` above on every spec file |
| With this change | **3568 examples, 0 failures** (96.88% line / 84.07% branch coverage) |

CI in this repo runs on `rails 8.0.2.1` and covers the no-regression side. Worth considering a Rails 8.1 entry in the CI matrix as a follow-up, since nothing here currently exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
